### PR TITLE
Change some syntax. Probably due to having an older go compiler.

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,7 @@ func (c *Client) Ping() bool {
 	case <-time.After(500 * time.Millisecond):
 		return false
 	}
+	return false
 }
 
 func (c *Client) Connect(addr, user, pass string) error {

--- a/connection.go
+++ b/connection.go
@@ -68,6 +68,7 @@ func (c *Connection) ErrOrOK() error {
 	case <-c.OKs:
 		return nil
 	}
+	return nil
 }
 
 func (c *Connection) Send(packet Packet) {

--- a/packets.go
+++ b/packets.go
@@ -83,6 +83,7 @@ func (p *SubPacket) Encode() []byte {
 	} else {
 		return []byte(fmt.Sprintf("SUB %s %d\r\n", p.Subject, p.ID))
 	}
+	return nil
 }
 
 type UnsubPacket struct {
@@ -101,20 +102,11 @@ type PubPacket struct {
 
 func (p *PubPacket) Encode() []byte {
 	if p.ReplyTo != "" {
-		return []byte(
-			fmt.Sprintf(
-				"PUB %s %s %d\r\n%s\r\n",
-				p.Subject, p.ReplyTo, len(p.Payload), p.Payload,
-			),
-		)
+		return []byte(fmt.Sprintf("PUB %s %s %d\r\n%s\r\n", p.Subject, p.ReplyTo, len(p.Payload), p.Payload))
 	} else {
-		return []byte(
-			fmt.Sprintf(
-				"PUB %s %d\r\n%s\r\n",
-				p.Subject, len(p.Payload), p.Payload,
-			),
-		)
+		return []byte(fmt.Sprintf("PUB %s %d\r\n%s\r\n", p.Subject, len(p.Payload), p.Payload))
 	}
+	return nil
 }
 
 type MsgPacket struct {
@@ -126,18 +118,9 @@ type MsgPacket struct {
 
 func (p *MsgPacket) Encode() []byte {
 	if p.ReplyTo != "" {
-		return []byte(
-			fmt.Sprintf(
-				"MSG %s %d %s %d\r\n%s\r\n",
-				p.Subject, p.SubID, p.ReplyTo, len(p.Payload), p.Payload,
-			),
-		)
+		return []byte(fmt.Sprintf("MSG %s %d %s %d\r\n%s\r\n", p.Subject, p.SubID, p.ReplyTo, len(p.Payload), p.Payload))
 	} else {
-		return []byte(
-			fmt.Sprintf(
-				"MSG %s %d %d\r\n%s\r\n",
-				p.Subject, p.SubID, len(p.Payload), p.Payload,
-			),
-		)
+		return []byte(fmt.Sprintf("MSG %s %d %d\r\n%s\r\n", p.Subject, p.SubID, len(p.Payload), p.Payload))
 	}
+	return nil
 }

--- a/parser.go
+++ b/parser.go
@@ -102,6 +102,7 @@ func readWord(io *bufio.Reader) ([]byte, error) {
 			word.WriteByte(next)
 		}
 	}
+	return nil, nil
 }
 
 func readNBytes(payloadLen int, io *bufio.Reader) ([]byte, error) {


### PR DESCRIPTION
I'm using the Altoros vagrant installer and was running into the "deadlock in the gorouter" issue so I thought I'd update to the latest gorouter code (and submodules). When trying to compile using this go version ...

```
vagrant@precise64:/vagrant/gorouter$ ./bin/go version
go version go1.0.3
```

I would get the following syntax errors. Once I made the changes in this PR, the program compiled and appears to be running OK. I'm not expecting this PR to be merged, but I thought I'd bring it to your attention. Should the Altoros cf-vagrant-installer code or other code be updated to use a later version of `go`?

Thanks! Luke

```
vagrant@precise64:/vagrant/gorouter$ ./bin/go install router/router
# github.com/vito/yagnats
src/github.com/vito/yagnats/packets.go:108: syntax error: unexpected comma
src/github.com/vito/yagnats/packets.go:115: syntax error: unexpected comma
src/github.com/vito/yagnats/packets.go:133: syntax error: unexpected comma
src/github.com/vito/yagnats/packets.go:140: syntax error: unexpected comma
vagrant@precise64:/vagrant/gorouter$ vim src/github.com/vito/yagnats/packets.go 
vagrant@precise64:/vagrant/gorouter$ ./bin/go install router/router
# github.com/vito/yagnats
src/github.com/vito/yagnats/packets.go:104: syntax error: unexpected string literal
src/github.com/vito/yagnats/packets.go:120: syntax error: unexpected semicolon or newline
vagrant@precise64:/vagrant/gorouter$ vim src/github.com/vito/yagnats/packets.go 
vagrant@precise64:/vagrant/gorouter$ ./bin/go install router/router
# github.com/vito/yagnats
src/github.com/vito/yagnats/client.go:34: function ends without a return statement
src/github.com/vito/yagnats/connection.go:64: function ends without a return statement
src/github.com/vito/yagnats/packets.go:80: function ends without a return statement
src/github.com/vito/yagnats/packets.go:102: function ends without a return statement
src/github.com/vito/yagnats/packets.go:117: function ends without a return statement
src/github.com/vito/yagnats/parser.go:88: function ends without a return statement
vagrant@precise64:/vagrant/gorouter$ vim src/github.com/vito/yagnats/packets.go 
vagrant@precise64:/vagrant/gorouter$ ./bin/go install router/router
# github.com/vito/yagnats
src/github.com/vito/yagnats/client.go:34: function ends without a return statement
src/github.com/vito/yagnats/connection.go:64: function ends without a return statement
src/github.com/vito/yagnats/packets.go:80: function ends without a return statement
src/github.com/vito/yagnats/packets.go:102: function ends without a return statement
src/github.com/vito/yagnats/packets.go:117: function ends without a return statement
src/github.com/vito/yagnats/parser.go:88: function ends without a return statement
```
