### PR TITLE
Fix PATH in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - go: tip
 
 install:
-  - export PATH=$GOPATH/bin:$PATH
+  - export PATH=$HOME/gopath/bin:$PATH
   - go get -v github.com/apcera/gnatsd
   - go get -v launchpad.net/gocheck
   - go get -v ./...


### PR DESCRIPTION
Travis uses GVM so `GOPATH` has two components. This means that a simply appending `/bin` to it won't work. You need to be explicit.
