### PR TITLE
use []byte for payloads, not string

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,8 +8,8 @@ type NATSClient interface {
 	Ping() bool
 	Connect(connectionProvider ConnectionProvider) error
 	Disconnect()
-	Publish(subject, payload string) error
-	PublishWithReplyTo(subject, payload, reply string) error
+	Publish(subject string, payload []byte) error
+	PublishWithReplyTo(subject, reply string, payload []byte) error
 	Subscribe(subject string, callback Callback) (int, error)
 	SubscribeWithQueue(subject, queue string, callback Callback) (int, error)
 	Unsubscribe(subscription int) error
@@ -30,8 +30,8 @@ type Client struct {
 
 type Message struct {
 	Subject string
-	Payload string
 	ReplyTo string
+	Payload []byte
 }
 
 type Subscription struct {
@@ -83,7 +83,7 @@ func (c *Client) Disconnect() {
 	conn.Disconnect()
 }
 
-func (c *Client) Publish(subject, payload string) error {
+func (c *Client) Publish(subject string, payload []byte) error {
 	conn := <-c.connection
 
 	conn.Send(
@@ -96,14 +96,14 @@ func (c *Client) Publish(subject, payload string) error {
 	return conn.ErrOrOK()
 }
 
-func (c *Client) PublishWithReplyTo(subject, payload, reply string) error {
+func (c *Client) PublishWithReplyTo(subject, reply string, payload []byte) error {
 	conn := <-c.connection
 
 	conn.Send(
 		&PubPacket{
 			Subject: subject,
-			Payload: payload,
 			ReplyTo: reply,
+			Payload: payload,
 		},
 	)
 

--- a/client_test.go
+++ b/client_test.go
@@ -115,8 +115,8 @@ func (s *YSuite) TestClientSubscribe(c *C) {
 }
 
 func (s *YSuite) TestClientUnsubscribe(c *C) {
-	payload1 := make(chan string)
-	payload2 := make(chan string)
+	payload1 := make(chan []byte)
+	payload2 := make(chan []byte)
 
 	sid1, _ := s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload1 <- msg.Payload
@@ -126,14 +126,14 @@ func (s *YSuite) TestClientUnsubscribe(c *C) {
 		payload2 <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload1, 500)
 	waitReceive(c, "hello!", payload2, 500)
 
 	s.Client.Unsubscribe(sid1)
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	select {
 	case <-payload1:
@@ -145,13 +145,13 @@ func (s *YSuite) TestClientUnsubscribe(c *C) {
 }
 
 func (s *YSuite) TestClientSubscribeAndUnsubscribe(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	sid1, _ := s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
@@ -161,7 +161,7 @@ func (s *YSuite) TestClientSubscribeAndUnsubscribe(c *C) {
 		payload <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
@@ -183,7 +183,7 @@ func (s *YSuite) TestClientAutoResubscribe(c *C) {
 		Password: "nats",
 	})
 
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	durableClient.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
@@ -196,7 +196,7 @@ func (s *YSuite) TestClientAutoResubscribe(c *C) {
 
 	waitUntilNatsUp(4213)
 
-	durableClient.Publish("some.subject", "hello!")
+	durableClient.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 }
@@ -205,11 +205,11 @@ func (s *YSuite) TestClientConnectCallback(c *C) {
 	doomedNats := startNats(4213)
 	defer stopCmd(doomedNats)
 
-	connectionChannel := make(chan string)
+	connectionChannel := make(chan []byte)
 
 	newClient := NewClient()
 	newClient.ConnectedCallback = func() {
-		connectionChannel <- "yo"
+		connectionChannel <- []byte("yo")
 	}
 
 	newClient.Connect(&ConnectionInfo{
@@ -225,11 +225,11 @@ func (s *YSuite) TestClientReconnectCallback(c *C) {
 	doomedNats := startNats(4213)
 	defer stopCmd(doomedNats)
 
-	connectionChannel := make(chan string)
+	connectionChannel := make(chan []byte)
 
 	durableClient := NewClient()
 	durableClient.ConnectedCallback = func() {
-		connectionChannel <- "yo"
+		connectionChannel <- []byte("yo")
 	}
 
 	durableClient.Connect(&ConnectionInfo{
@@ -256,11 +256,11 @@ func (s *YSuite) TestClientReconnectCallbackSelfPublish(c *C) {
 	doomedNats := startNats(4213)
 	defer stopCmd(doomedNats)
 
-	connectionChannel := make(chan string)
+	connectionChannel := make(chan []byte)
 
 	durableClient := NewClient()
 	durableClient.ConnectedCallback = func() {
-		durableClient.Publish("started", "hi")
+		durableClient.Publish("started", []byte("hi"))
 	}
 
 	durableClient.Connect(&ConnectionInfo{
@@ -277,7 +277,7 @@ func (s *YSuite) TestClientReconnectCallbackSelfPublish(c *C) {
 	}
 
 	durableClient.Subscribe("started", func(*Message) {
-		connectionChannel <- "yo"
+		connectionChannel <- []byte("yo")
 	})
 
 	stopCmd(doomedNats)
@@ -301,19 +301,19 @@ func (s *YSuite) TestClientSubscribeInvalidSubject(c *C) {
 }
 
 func (s *YSuite) TestClientUnsubscribeAll(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
 	s.Client.UnsubscribeAll("some.subject")
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	select {
 	case <-payload:
@@ -323,19 +323,19 @@ func (s *YSuite) TestClientUnsubscribeAll(c *C) {
 }
 
 func (s *YSuite) TestClientPubSub(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 }
 
 func (s *YSuite) TestClientPubSubWithQueue(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	s.Client.SubscribeWithQueue("some.subject", "some-queue", func(msg *Message) {
 		payload <- msg.Payload
@@ -345,7 +345,7 @@ func (s *YSuite) TestClientPubSubWithQueue(c *C) {
 		payload <- msg.Payload
 	})
 
-	s.Client.Publish("some.subject", "hello!")
+	s.Client.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
@@ -357,23 +357,23 @@ func (s *YSuite) TestClientPubSubWithQueue(c *C) {
 }
 
 func (s *YSuite) TestClientPublishWithReply(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	s.Client.Subscribe("some.request", func(msg *Message) {
-		s.Client.Publish(msg.ReplyTo, "response!")
+		s.Client.Publish(msg.ReplyTo, []byte("response!"))
 	})
 
 	s.Client.Subscribe("some.reply", func(msg *Message) {
 		payload <- msg.Payload
 	})
 
-	s.Client.PublishWithReplyTo("some.request", "hello!", "some.reply")
+	s.Client.PublishWithReplyTo("some.request", "some.reply", []byte("hello!"))
 
 	waitReceive(c, "response!", payload, 500)
 }
 
 func (s *YSuite) TestClientDisconnect(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
@@ -388,7 +388,7 @@ func (s *YSuite) TestClientDisconnect(c *C) {
 		Password: "nats",
 	})
 
-	otherClient.Publish("some.subject", "hello!")
+	otherClient.Publish("some.subject", []byte("hello!"))
 
 	select {
 	case <-payload:
@@ -398,7 +398,7 @@ func (s *YSuite) TestClientDisconnect(c *C) {
 }
 
 func (s *YSuite) TestClientMessageWithoutSubscription(c *C) {
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	sid, err := s.Client.Subscribe("some.subject", func(msg *Message) {
 		payload <- msg.Payload
@@ -412,8 +412,8 @@ func (s *YSuite) TestClientMessageWithoutSubscription(c *C) {
 
 	delete(s.Client.subscriptions, sid)
 
-	s.Client.Publish("some.subject", "hello!")
-	s.Client.Publish("some.other.subject", "hello to other!")
+	s.Client.Publish("some.subject", []byte("hello!"))
+	s.Client.Publish("some.other.subject", []byte("hello to other!"))
 
 	waitReceive(c, "hello to other!", payload, 500)
 }
@@ -454,10 +454,10 @@ func (s *YSuite) TestClientMessageWhileResubscribing(c *C) {
 		},
 	})
 
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	client.Subscribe("foo", func(msg *Message) {
-		payload <- "resubscribed!"
+		payload <- []byte("resubscribed!")
 	})
 
 	client.Subscribe("bar", func(msg *Message) {
@@ -477,7 +477,7 @@ func (s *YSuite) TestClientPubSubWithQueueReconnectsWithQueue(c *C) {
 		Password: "nats",
 	})
 
-	payload := make(chan string)
+	payload := make(chan []byte)
 
 	durableClient.SubscribeWithQueue("some.subject", "some-queue", func(msg *Message) {
 		payload <- msg.Payload
@@ -487,7 +487,7 @@ func (s *YSuite) TestClientPubSubWithQueueReconnectsWithQueue(c *C) {
 		payload <- msg.Payload
 	})
 
-	durableClient.Publish("some.subject", "hello!")
+	durableClient.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
@@ -505,7 +505,7 @@ func (s *YSuite) TestClientPubSubWithQueueReconnectsWithQueue(c *C) {
 
 	waitUntilNatsUp(4213)
 
-	durableClient.Publish("some.subject", "hello!")
+	durableClient.Publish("some.subject", []byte("hello!"))
 
 	waitReceive(c, "hello!", payload, 500)
 
@@ -516,10 +516,10 @@ func (s *YSuite) TestClientPubSubWithQueueReconnectsWithQueue(c *C) {
 	}
 }
 
-func waitReceive(c *C, expected string, from chan string, ms time.Duration) {
+func waitReceive(c *C, expected string, from chan []byte, ms time.Duration) {
 	select {
 	case msg := <-from:
-		c.Assert(msg, Equals, expected)
+		c.Assert(string(msg), Equals, expected)
 	case <-time.After(ms * time.Millisecond):
 		c.Error("Timed out waiting for message.")
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -20,7 +20,7 @@ func (s *CSuite) TestConnectionPong(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte("PING\r\n")),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 	}
 
 	// fill in a fake connection
@@ -36,7 +36,7 @@ func (s *CSuite) TestConnectionUnexpectedError(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte("-ERR 'foo'\r\nPING\r\n")),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 	}
 
 	// fill in a fake connection
@@ -52,7 +52,7 @@ func (s *CSuite) TestConnectionUnexpectedPong(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte("PONG\r\nPING\r\n")),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 	}
 
 	// fill in a fake connection
@@ -68,7 +68,7 @@ func (s *CSuite) TestConnectionDisconnect(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte{}),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 		Closed:      false,
 	}
 
@@ -85,7 +85,7 @@ func (s *CSuite) TestConnectionErrOrOKReturnsErrorOnDisconnect(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte{}),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 	}
 
 	// fill in a fake connection
@@ -117,7 +117,7 @@ func (s *CSuite) TestConnectionOnMessageCallback(c *C) {
 	conn := &fakeConn{
 		ReadBuffer:  bytes.NewBuffer([]byte("MSG foo 1 5\r\nhello\r\n")),
 		WriteBuffer: bytes.NewBuffer([]byte{}),
-		WriteChan:   make(chan string),
+		WriteChan:   make(chan []byte),
 		Closed:      false,
 	}
 
@@ -135,7 +135,7 @@ func (s *CSuite) TestConnectionOnMessageCallback(c *C) {
 	select {
 	case msg := <-messages:
 		c.Assert(msg.SubID, Equals, 1)
-		c.Assert(msg.Payload, Equals, "hello")
+		c.Assert(string(msg.Payload), Equals, "hello")
 	case <-time.After(1 * time.Second):
 		c.Error("Did not receive message.")
 	}

--- a/examples/fast-producer.go
+++ b/examples/fast-producer.go
@@ -24,7 +24,7 @@ func main() {
 	bigbyte := make([]byte, 512000)
 	go func() {
 		for {
-			client.Publish("foo", string(bigbyte))
+			client.Publish("foo", bigbyte)
 		}
 	}()
 

--- a/examples/stress.go
+++ b/examples/stress.go
@@ -29,7 +29,7 @@ func main() {
 
 	go func() {
 		for {
-			client.Publish("foo", "hi")
+			client.Publish("foo", []byte("hi"))
 		}
 	}()
 

--- a/fakeyagnats/fake_yagnats.go
+++ b/fakeyagnats/fake_yagnats.go
@@ -61,7 +61,7 @@ func (f *FakeYagnats) Disconnect() {
 }
 
 func (f *FakeYagnats) Publish(subject string, payload []byte) error {
-	return f.PublishWithReplyTo(subject, payload, "")
+	return f.PublishWithReplyTo(subject, "", payload)
 }
 
 func (f *FakeYagnats) PublishWithReplyTo(subject, reply string, payload []byte) error {

--- a/fakeyagnats/fake_yagnats.go
+++ b/fakeyagnats/fake_yagnats.go
@@ -60,15 +60,15 @@ func (f *FakeYagnats) Disconnect() {
 	return
 }
 
-func (f *FakeYagnats) Publish(subject, payload string) error {
+func (f *FakeYagnats) Publish(subject string, payload []byte) error {
 	return f.PublishWithReplyTo(subject, payload, "")
 }
 
-func (f *FakeYagnats) PublishWithReplyTo(subject, payload, reply string) error {
+func (f *FakeYagnats) PublishWithReplyTo(subject, reply string, payload []byte) error {
 	message := yagnats.Message{
 		Subject: subject,
-		Payload: payload,
 		ReplyTo: reply,
+		Payload: payload,
 	}
 
 	f.PublishedMessages[subject] = append(f.PublishedMessages[subject], message)

--- a/fakeyagnats/fake_yagnats_test.go
+++ b/fakeyagnats/fake_yagnats_test.go
@@ -1,0 +1,15 @@
+package fakeyagnats
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry/yagnats"
+)
+
+func FunctionTakingNATSClient(yagnats.NATSClient) {
+
+}
+
+func TestCanPassFakeYagnatsAsNATSClient(t *testing.T) {
+	FunctionTakingNATSClient(New())
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -99,7 +99,7 @@ func waitUntilNatsDown(port int) error {
 type fakeConn struct {
 	ReadBuffer  *bytes.Buffer
 	WriteBuffer *bytes.Buffer
-	WriteChan   chan string
+	WriteChan   chan []byte
 	Closed      bool
 
 	sync.RWMutex
@@ -125,7 +125,7 @@ func (f *fakeConn) Write(b []byte) (n int, err error) {
 	}
 
 	if f.WriteChan != nil {
-		f.WriteChan <- string(b)
+		f.WriteChan <- b
 	}
 
 	return f.WriteBuffer.Write(b)

--- a/packets.go
+++ b/packets.go
@@ -96,7 +96,7 @@ func (p *UnsubPacket) Encode() []byte {
 type PubPacket struct {
 	Subject string
 	ReplyTo string
-	Payload string
+	Payload []byte
 }
 
 func (p *PubPacket) Encode() []byte {
@@ -121,7 +121,7 @@ type MsgPacket struct {
 	Subject string
 	SubID   int
 	ReplyTo string
-	Payload string
+	Payload []byte
 }
 
 func (p *MsgPacket) Encode() []byte {

--- a/packets_test.go
+++ b/packets_test.go
@@ -66,21 +66,21 @@ func (s *YSuite) TestSubEncodeWithNoQueue(c *C) {
 }
 
 func (s *YSuite) TestPubEncode(c *C) {
-	packet := &PubPacket{Subject: "some.subject", Payload: "sup?"}
+	packet := &PubPacket{Subject: "some.subject", Payload: []byte("sup?")}
 	c.Assert(string(packet.Encode()), Equals, "PUB some.subject 4\r\nsup?\r\n")
 }
 
 func (s *YSuite) TestPubEncodeWithReplyTo(c *C) {
-	packet := &PubPacket{Subject: "some.subject", ReplyTo: "some.reply", Payload: "sup?"}
+	packet := &PubPacket{Subject: "some.subject", ReplyTo: "some.reply", Payload: []byte("sup?")}
 	c.Assert(string(packet.Encode()), Equals, "PUB some.subject some.reply 4\r\nsup?\r\n")
 }
 
 func (s *YSuite) TestMsgEncode(c *C) {
-	packet := &MsgPacket{Subject: "some.subject", SubID: 42, Payload: "sup?"}
+	packet := &MsgPacket{Subject: "some.subject", SubID: 42, Payload: []byte("sup?")}
 	c.Assert(string(packet.Encode()), Equals, "MSG some.subject 42 4\r\nsup?\r\n")
 }
 
 func (s *YSuite) TestMsgEncodeWithReplyTo(c *C) {
-	packet := &MsgPacket{Subject: "some.subject", SubID: 42, ReplyTo: "some.reply", Payload: "sup?"}
+	packet := &MsgPacket{Subject: "some.subject", SubID: 42, ReplyTo: "some.reply", Payload: []byte("sup?")}
 	c.Assert(string(packet.Encode()), Equals, "MSG some.subject 42 some.reply 4\r\nsup?\r\n")
 }

--- a/parser.go
+++ b/parser.go
@@ -81,7 +81,7 @@ var PARSERS = map[string]Parser{
 			Subject: matches[1],
 			SubID:   subID,
 			ReplyTo: matches[4],
-			Payload: string(payload),
+			Payload: payload,
 		}, nil
 	},
 }


### PR DESCRIPTION
also swapped the order of PublishWithReplyTo's arguments to match the style of
SubscribeWithQueue (subject, reply, payload and subject, queue, callback).

fixes #4
