### PR TITLE
Use DialTimeout

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -90,7 +90,7 @@ func (c *ConnectionCluster) ProvideConnection() (*Connection, error) {
 }
 
 func (c *Connection) Dial() error {
-	conn, err := net.Dial("tcp", c.addr)
+	conn, err := net.DialTimeout("tcp", c.addr, 5 * time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Figured 5 sec was a good value.  If it takes longer than 5 sec to connect to NATs you've got bigger problems.

I decided against seeding the random ConnectionCluster.  I like the predictability that a non seeded connection pool provides.

I tried to write a test and had a heck of a time with it.  You can see what go itself did to test timeout here: http://golang.org/src/pkg/net/dial_test.go

Let me know if you want a test and I can perhaps look into perhaps some kind of mock or something?
