### PR TITLE
Retry in ConnectionCluster.ProvideConnection()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3,7 +3,6 @@ package yagnats
 import (
 	"bufio"
 	"errors"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -95,8 +94,14 @@ type ConnectionCluster struct {
 	Members []ConnectionProvider
 }
 
-func (c *ConnectionCluster) ProvideConnection() (*Connection, error) {
-	return c.Members[rand.Intn(len(c.Members))].ProvideConnection()
+func (c *ConnectionCluster) ProvideConnection() (conn *Connection, err error) {
+	for _, cp := range c.Members {
+		conn, err = cp.ProvideConnection()
+		if err == nil {
+			return conn, nil
+		}
+	}
+	return nil, err
 }
 
 func (c *Connection) Dial() error {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -12,11 +12,17 @@ import (
 )
 
 type FakeConnectionProvider struct {
-	ReadBuffer  string
-	WriteBuffer []byte
+	ReadBuffer   string
+	WriteBuffer  []byte
+	ReturnsError bool
 }
 
 func (c *FakeConnectionProvider) ProvideConnection() (*Connection, error) {
+	if c.ReturnsError {
+		err := errors.New("error on dialing")
+		return nil, err
+	}
+
 	connection := NewConnection("", "", "")
 
 	connection.conn = &fakeConn{


### PR DESCRIPTION
Recently I've encuntered the problem related to rand.Seed described in https://github.com/cloudfoundry/yagnats/issues/8 . At first I looked out the cause and wrote code to solve it by myself, then I've found the GitHub issue. However the issue has a related pull request and is closed, the problem of not-seeding rand seems left alone.

So I've decided to send a pull request with my first solution. It makes ConnectionCluster.provideConnection() to retry connecting to another NATS server when it failed to connect one.

If you don't like it, I'll send another (simpler) pull request that fixes seeding only.

Thanks in advance.
