### PR TITLE
Always close the connection to avoid sockets hanging in CLOSE_WAIT

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -191,6 +191,7 @@ func (c *Connection) receivePackets() {
 		packet, err := Parse(io)
 		if err != nil {
 			c.Logger().Errord(map[string]interface{}{"error": err.Error()}, "connection.packet.read-error")
+			c.Disconnect()
 			c.disconnected()
 			break
 		}


### PR DESCRIPTION
If a connection gets closed unexpectedly, it could generate "socket closed" read errors and `receivePackets` would mark it as disconnected to cause a new connection to be established by client, but it was not locally closing the socket causing it to hang around.

Related Story #109478174