### PR TITLE
Expose NATS options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.4
   - 1.5
+  - 1.6
   - tip
 
 matrix:
@@ -12,7 +12,7 @@ matrix:
 install:
   - export PATH=$HOME/gopath/bin:$PATH
   - go get -v github.com/nats-io/gnatsd
-  - go get -v launchpad.net/gocheck
+  - go get gopkg.in/check.v1
   - go get -v ./...
   - go build -v ./...
 

--- a/apcera_client_test.go
+++ b/apcera_client_test.go
@@ -6,8 +6,18 @@ import (
 
 	"github.com/nats-io/nats"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
+
+func (s *YSuite) TestApceraConnectWithOptions(c *C) {
+	opts := nats.DefaultOptions
+	opts.PingInterval = time.Duration(30) * time.Second
+	opts.Servers = []string{"nats://nats:nats@127.0.0.1:4223"}
+
+	client := Must(ConnectWithOptions(opts))
+
+	c.Assert(client.Options().PingInterval, Equals, opts.PingInterval)
+}
 
 func (s *YSuite) TestApceraCloseOnNewClient(c *C) {
 	client := Must(Connect([]string{"nats://nats:nats@127.0.0.1:4223"}))

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/connection_test.go
+++ b/connection_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 type CSuite struct {
@@ -76,7 +76,7 @@ func (s *CSuite) TestConnectionDisconnect(c *C) {
 
 	// fill in a fake connection
 	s.Connection.conn = conn
-	go s.Connection.receivePackets()
+	c.Assert(conn.Closed, Equals, false)
 
 	s.Connection.Disconnect()
 

--- a/fakeyagnats/fake_apcera_yagnats.go
+++ b/fakeyagnats/fake_apcera_yagnats.go
@@ -76,6 +76,10 @@ func (f *FakeNATSConn) Ping() bool {
 func (f *FakeNATSConn) Close() {
 }
 
+func (f *FakeNATSConn) Options() nats.Options {
+	return nats.Options{}
+}
+
 func (f *FakeNATSConn) Publish(subject string, payload []byte) error {
 	return f.PublishRequest(subject, "", payload)
 }

--- a/packets_test.go
+++ b/packets_test.go
@@ -2,7 +2,7 @@ package yagnats
 
 import (
 	"encoding/json"
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *YSuite) TestInfoEncode(c *C) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,7 +3,7 @@ package yagnats
 import (
 	"bufio"
 	"bytes"
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 func (s *YSuite) TestParsePing(c *C) {


### PR DESCRIPTION
We need to expose the nats.Options member of the nats.Conn struct in order to adjust params such as the PingInterval, which greatly affects performance during reconnects.